### PR TITLE
リスト11.27: 調停する対象をmmio_membusに変更するのミスを修正

### DIFF
--- a/basic/contents/12-impl-mmio.re
+++ b/basic/contents/12-impl-mmio.re
@@ -622,7 +622,7 @@ coreモジュールからmmio_controllerモジュールへのアクセスを調�
     always_comb {
         i_membus.ready  = @<b>|mmio_|membus.ready && !d_membus.valid;
         i_membus.rvalid = @<b>|mmio_|membus.rvalid && memarb_last_i;
-        i_membus.rdata  = if memarb_last_iaddr[2] == 0 ? @<b>|mmio_|membus.rdata[31:0] : mmio_|membus.rdata[63:32];
+        i_membus.rdata  = if memarb_last_iaddr[2] == 0 ? @<b>|mmio_|membus.rdata[31:0] : @<b>|mmio_|membus.rdata[63:32];
 
         d_membus.ready  = @<b>|mmio_|membus.ready;
         d_membus.rvalid = @<b>|mmio_|membus.rvalid && !memarb_last_i;


### PR DESCRIPTION
https://cpu.kanataso.net/12-impl-mmio.html#ram%E3%81%A8mmio-controller%E3%83%A2%E3%82%B7%E3%82%99%E3%83%A5%E3%83%BC%E3%83%AB%E3%82%92%E6%8E%A5%E7%B6%9A%E3%81%99%E3%82%8B

差分のハイライトが崩れていた部分を修正しました